### PR TITLE
Feat: Feature Like/Unlike Post

### DIFF
--- a/_cmd/main.go
+++ b/_cmd/main.go
@@ -40,6 +40,10 @@ func main() {
 	CommentHandler := handler.NewCommentHandler(CommentService)
 	CommentRouter := router.NewCommentRouter(CommentHandler)
 
+	LikeService := service.NewLikeService(postRepo)
+	LikeHandler := handler.NewLikeHandler(LikeService)
+	LikeRouter := router.NewLikeRouter(LikeHandler)
+
 	r := gin.Default()
 
 	api := r.Group("/api")
@@ -53,6 +57,8 @@ func main() {
 	postRouter.PostMiddlewareRoutes(postGroup)
 
 	CommentRouter.CommentRoutes(postGroup)
+
+	LikeRouter.LikeRouters(postGroup)
 
 	port := os.Getenv("PORT")
 	r.Run(":" + port)

--- a/internal/handler/like.go
+++ b/internal/handler/like.go
@@ -1,0 +1,40 @@
+package handler
+
+import (
+	"github.com/Fillybodyknow/blog-api/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+type LikeHandler struct {
+	LikeServiceInterface service.LikeServiceInterface
+}
+
+func NewLikeHandler(likeService service.LikeServiceInterface) *LikeHandler {
+	return &LikeHandler{LikeServiceInterface: likeService}
+}
+
+func (h *LikeHandler) LikePost(c *gin.Context) {
+	UserID, _ := c.Get("user_id")
+	PostID := c.Param("post_id")
+
+	err := h.LikeServiceInterface.LikePost(PostID, UserID.(string))
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(200, gin.H{"message": "Post liked successfully"})
+}
+
+func (h *LikeHandler) UnlikePost(c *gin.Context) {
+	UserID, _ := c.Get("user_id")
+	PostID := c.Param("post_id")
+
+	err := h.LikeServiceInterface.UnlikePost(PostID, UserID.(string))
+	if err != nil {
+		c.JSON(400, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(200, gin.H{"message": "Post unliked successfully"})
+}

--- a/internal/repository/like_repository.go
+++ b/internal/repository/like_repository.go
@@ -1,0 +1,78 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/Fillybodyknow/blog-api/internal/models"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type LikeRepositoryInterface interface {
+	InsertLike(ctx context.Context, like *models.Like, PostID primitive.ObjectID) error
+	DeleteLike(ctx context.Context, PostID primitive.ObjectID, LikeID primitive.ObjectID) error
+	GetLikes(ctx context.Context, PostID primitive.ObjectID) ([]models.Like, error)
+	FindLikeByUserID(ctx context.Context, PostID primitive.ObjectID, userID primitive.ObjectID) (*models.Like, error)
+	FindLikeByID(ctx context.Context, PostID primitive.ObjectID, LikeID primitive.ObjectID) (*models.Like, error)
+}
+
+func (r *PostRepository) InsertLike(ctx context.Context, like *models.Like, PostID primitive.ObjectID) error {
+	err := r.Collection.FindOneAndUpdate(ctx, bson.M{"_id": PostID}, bson.M{"$push": bson.M{"likes": like}}).Err()
+	return err
+}
+
+func (r *PostRepository) DeleteLike(ctx context.Context, PostID primitive.ObjectID, LikeID primitive.ObjectID) error {
+	filter := bson.M{"_id": PostID}
+	update := bson.M{"$pull": bson.M{"likes": bson.M{"_id": LikeID}}}
+	_, err := r.Collection.UpdateOne(ctx, filter, update)
+	return err
+}
+
+func (r *PostRepository) GetLikes(ctx context.Context, PostID primitive.ObjectID) ([]models.Like, error) {
+	var post models.Post
+	err := r.Collection.FindOne(ctx, bson.M{"_id": PostID}).Decode(&post)
+	if err != nil {
+		return nil, err
+	}
+	return post.Likes, nil
+}
+
+func (r *PostRepository) FindLikeByUserID(ctx context.Context, PostID primitive.ObjectID, userID primitive.ObjectID) (*models.Like, error) {
+	filter := bson.M{"_id": PostID, "likes.user_id": userID}
+	projection := bson.M{"likes": bson.M{"$elemMatch": bson.M{"user_id": userID}}}
+
+	var result struct {
+		Likes []models.Like `bson:"likes"`
+	}
+
+	err := r.Collection.FindOne(ctx, filter, options.FindOne().SetProjection(projection)).Decode(&result)
+	if err != nil {
+		return nil, err
+	}
+	if len(result.Likes) == 0 {
+		return nil, mongo.ErrNoDocuments
+	}
+
+	return &result.Likes[0], nil
+}
+
+func (r *PostRepository) FindLikeByID(ctx context.Context, PostID primitive.ObjectID, LikeID primitive.ObjectID) (*models.Like, error) {
+	filter := bson.M{"_id": PostID, "likes._id": LikeID}
+	projection := bson.M{"likes": bson.M{"$elemMatch": bson.M{"_id": LikeID}}}
+
+	var result struct {
+		Likes []models.Like `bson:"likes"`
+	}
+
+	err := r.Collection.FindOne(ctx, filter, options.FindOne().SetProjection(projection)).Decode(&result)
+	if err != nil {
+		return nil, err
+	}
+	if len(result.Likes) == 0 {
+		return nil, mongo.ErrNoDocuments
+	}
+
+	return &result.Likes[0], nil
+}

--- a/internal/router/like.go
+++ b/internal/router/like.go
@@ -1,0 +1,21 @@
+package router
+
+import (
+	"github.com/Fillybodyknow/blog-api/internal/handler"
+	"github.com/Fillybodyknow/blog-api/internal/middleware"
+	"github.com/gin-gonic/gin"
+)
+
+type LikeRouter struct {
+	LikeHandler *handler.LikeHandler
+}
+
+func NewLikeRouter(likeHandler *handler.LikeHandler) *LikeRouter {
+	return &LikeRouter{LikeHandler: likeHandler}
+}
+
+func (r *LikeRouter) LikeRouters(rg *gin.RouterGroup) {
+	rg.Use(middleware.AuthMiddleware())
+	rg.POST("/:post_id/like", r.LikeHandler.LikePost)
+	rg.DELETE("/:post_id/like", r.LikeHandler.UnlikePost)
+}

--- a/internal/service/like_service.go
+++ b/internal/service/like_service.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Fillybodyknow/blog-api/internal/models"
+	"github.com/Fillybodyknow/blog-api/internal/repository"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type LikeServiceInterface interface {
+	LikePost(PostIDStr string, userIDStr string) error
+	UnlikePost(PostIDStr string, userIDStr string) error
+}
+
+type LikeService struct {
+	LikeRepository repository.LikeRepositoryInterface
+}
+
+func NewLikeService(likeRepository repository.LikeRepositoryInterface) *LikeService {
+	return &LikeService{LikeRepository: likeRepository}
+}
+
+func (s *LikeService) LikePost(PostIDStr string, userIDStr string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	PostID, _ := primitive.ObjectIDFromHex(PostIDStr)
+	UserID, _ := primitive.ObjectIDFromHex(userIDStr)
+
+	existingLike, _ := s.LikeRepository.FindLikeByUserID(ctx, PostID, UserID)
+	if existingLike != nil {
+		return errors.New("คุณได้ Like โพสต์นี้ไปแล้ว")
+	}
+
+	like := &models.Like{
+		ID:     primitive.NewObjectID(),
+		UserID: UserID,
+	}
+	err := s.LikeRepository.InsertLike(ctx, like, PostID)
+	if err != nil {
+		return errors.New("เกิดข้อผิดพลาดในการ Like โพสต์ ขออภัยในความไม่สะดวก")
+	}
+	return nil
+}
+
+func (s *LikeService) UnlikePost(PostIDStr string, userIDStr string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	PostID, _ := primitive.ObjectIDFromHex(PostIDStr)
+	UserID, _ := primitive.ObjectIDFromHex(userIDStr)
+
+	isOwnerLike, _ := s.LikeRepository.FindLikeByUserID(ctx, PostID, UserID)
+	if isOwnerLike == nil {
+		return errors.New("คุณยังไม่ได้ Like โพสต์นี้")
+	}
+
+	err := s.LikeRepository.DeleteLike(ctx, PostID, isOwnerLike.ID)
+	if err != nil {
+		return errors.New("เกิดข้อผิดพลาดในการ Unlike โพสต์ ขออภัยในความไม่สะดวก -> " + err.Error())
+	}
+	return nil
+}


### PR DESCRIPTION
เพิ่มฟีเจอร์ Like / Unlike โพสต์
💡 ฟีเจอร์ที่เพิ่มเข้ามา
Like โพสต์
   - Endpoint: POST /:post_id/like
   - ผู้ใช้ต้องเข้าสู่ระบบ (แนบ Bearer Token)
   - สามารถกด Like โพสต์ได้ครั้งเดียว
   - ตรวจสอบไม่ให้ Like ซ้ำ

Unlike โพสต์
    - Endpoint: DELETE /:post_id/like
    - ผู้ใช้ต้องเข้าสู่ระบบ (แนบ Bearer Token)
    - ใช้สำหรับยกเลิก Like จากโพสต์ที่เคยกด
    - แจ้งเตือนหากยังไม่เคย Like โพสต์นี้